### PR TITLE
Add nyc for coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *\.sh
 /node_modules
 /npm-debug.log
+.nyc_output
+coverage

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,8 @@
+{
+  "all": true,
+  "cache": false,
+  "reporter": [
+    "lcov",
+    "text"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 JsonML-related tools.
 
+## Forked Library
+
+From from [benjycui/jsonml.js](https://github.com/benjycui/jsonml.js) since it is used by many CondeNast applications but not actively supported. Fork created by [pgoldrbx](https://github.com/pgoldrbx).
+
 ## Usage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-fix": "eslint --fix ./lib/utils.js ./test",
     "babel": "babel src --out-dir lib",
     "pub": "npm run babel && npm publish && rm -rf lib",
-    "test": "mocha"
+    "test": "nyc mocha"
   },
   "babel": {
     "presets": [
@@ -40,6 +40,7 @@
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.10.2",
     "eslint-config-egg": "^2.0.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "nyc": "^11.6.0"
   }
 }


### PR DESCRIPTION
Add [nyc](https://github.com/istanbuljs/nyc) (Istanbul command-line interface) to generate coverage reports. With the minimal integration, coverage information will be logged after running tests. This helps to visualize current coverage and areas in need of tests.

```sh
$ npm test
```

![nyc-coverage](https://user-images.githubusercontent.com/4885634/31854258-c9f29faa-b663-11e7-84c6-2d3a95acd06a.png)

