### PR TITLE
Cleanup existing lint rules on utils

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,4 +2,7 @@
 
 module.exports = {
   extends: 'eslint-config-egg',
+  rules: {
+    yoda: 'off'
+  }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,7 +82,7 @@ exports.setAttribute = function setAttribute(jml, key, value) {
   getAttributes(jml, true)[key] = value;
 };
 
-const appendChild = exports.appendChild = function appendChild(parent, child) {
+exports.appendChild = function appendChild(parent, child) {
   if (!isArray(parent)) {
     throw new SyntaxError('invalid JsonML');
   }
@@ -99,12 +99,12 @@ const appendChild = exports.appendChild = function appendChild(parent, child) {
   } else if (child && 'object' === typeof child) {
     if (isArray(child)) {
       if (!isElement(child)) {
-	                                                                                                                                                                throw new SyntaxError('invalid JsonML');
+        throw new SyntaxError('invalid JsonML');
       }
 
       if (typeof arguments[2] === 'function') {
-	// onAppend callback for JBST use
-	                                                                                                                                                                (arguments[2])(parent, child);
+        // onAppend callback for JBST use
+        arguments[2](parent, child);
       }
 
       // result was a JsonML node


### PR DESCRIPTION
This PR fixes existing issues based on the project lint setup.

- disable `yoda` rule (allow literal on left side of comparison) - this is used consistently throughout the project, so it seemed worthy of disabling the rule
- fix whitespace
- remove unused variable

Before
```sh
$ npm run lint
lib/utils.js
   85:7    error  'appendChild' is defined but never used                 no-unused-vars
   99:23   error  Expected literal to be on the right side of ===         yoda
  102:2    error  Mixed spaces and tabs                                   no-mixed-spaces-and-tabs
  102:162  error  Expected indentation of 8 space characters but found 0  indent
  107:2    error  Mixed spaces and tabs                                   no-mixed-spaces-and-tabs
  107:162  error  Expected indentation of 8 space characters but found 0  indent
  107:162  error  Gratuitous parentheses around expression                no-extra-parens
  123:14   error  Expected literal to be on the right side of !==         yoda
  129:39   error  Expected literal to be on the right side of ===         yoda

✖ 9 problems (9 errors, 0 warnings)
```

