### PR TITLE
fix: use html.isRaw method when appending child Markup instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *\.sh
 /node_modules
 /npm-debug.log
+.nyc_output
+coverage

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,8 @@
+{
+  "all": true,
+  "cache": false,
+  "reporter": [
+    "lcov",
+    "text"
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
+  - "8"
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # jsonml.js
 
-[![](https://img.shields.io/travis/benjycui/jsonml.js.svg?style=flat-square)](https://travis-ci.org/benjycui/jsonml.js)
-[![npm package](https://img.shields.io/npm/v/jsonml.js.svg?style=flat-square)](https://www.npmjs.org/package/jsonml.js)
-[![NPM downloads](http://img.shields.io/npm/dm/jsonml.js.svg?style=flat-square)](https://npmjs.org/package/jsonml.js)
-[![Dependency Status](https://david-dm.org/benjycui/jsonml.js.svg?style=flat-square)](https://david-dm.org/benjycui/jsonml.js)
+[![Build Status](https://travis-ci.org/CondeNast/jsonml.js.svg?branch=master)](https://travis-ci.org/CondeNast/jsonml.js)
 
 JsonML-related tools.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 JsonML-related tools.
 
+## Forked Library
+
+From from [benjycui/jsonml.js](https://github.com/benjycui/jsonml.js) since it is used by many CondeNast applications but not actively supported. Fork created by [pgoldrbx](https://github.com/pgoldrbx).
+
 ## Usage
 
 ```bash

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const isRaw = require('./html').isRaw;
+
 const isArray = Array.isArray || function isArray(val) {
   return val instanceof Array;
 };
@@ -110,7 +112,7 @@ exports.appendChild = function appendChild(parent, child) {
       // result was a JsonML node
       parent.push(child);
 
-    } else if (exports.isRaw(child)) {
+    } else if (isRaw(child)) {
 
       // result was a JsonML node
       parent.push(child);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-fix": "eslint --fix ./lib/utils.js ./test",
     "babel": "babel src --out-dir lib",
     "pub": "npm run babel && npm publish && rm -rf lib",
-    "test": "mocha"
+    "test": "nyc mocha"
   },
   "babel": {
     "presets": [
@@ -40,6 +40,7 @@
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.10.2",
     "eslint-config-egg": "^2.0.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "nyc": "^11.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jsonml.js",
+  "name": "@condenast/jsonml.js",
   "version": "0.1.1",
   "description": "JsonML-related tools.",
   "main": "index.js",
@@ -21,6 +21,14 @@
     "xml",
     "html"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CondeNast/jsonml.js"
+  },
+  "bugs": {
+    "url": "https://github.com/CondeNast/jsonml.js/issues"
+  },
+  "homepage": "https://github.com/CondeNast/jsonml.js",
   "contributors": [
     {
       "name": "Stephen M. McKamey"
@@ -28,6 +36,10 @@
     {
       "name": "Benjy Cui",
       "email": "benjytrys@gmail.com"
+    },
+    {
+      "name": "Phil Gold",
+      "email": "pgold@rubixmedia.com"
     }
   ],
   "license": "MIT",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const html = require('../lib/html');
 const utils = require('../lib/utils');
 
 describe('utils', function() {
@@ -311,18 +312,16 @@ describe('utils', function() {
     });
 
     describe('when appending a raw child', function() {
-      // @TODO - this will currently throw an error due to missing function `isRaw`
-      xit('should append to the parent', function() {
+      it('should append to the parent', function() {
         const jml = ['div'];
-        const child = new function RawChild() {};
+        const child = html.raw('string value');
         utils.appendChild(jml, child);
-        assert.strictEqual(jml, ['div', child]);
+        assert.deepEqual(jml, ['div', child]);
       });
     });
 
     describe('when appending attributes', function() {
-      // @TODO - this will currently throw an error due to missing function `isRaw`
-      xit('should add attributes to the parent element', function() {
+      it('should add attributes to the parent element', function() {
         const jml = ['div'];
         const attrs = { a: 1 };
         utils.appendChild(jml, attrs);


### PR DESCRIPTION
Fixes #9

- Use `isRaw` from `html` interface

This fixes the error thrown when `isRaw` is `undefined`